### PR TITLE
Add Coming Soon splash page

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (pathname.startsWith('/_next/') || pathname === '/favicon.ico') {
+    return NextResponse.next();
+  }
+
+  if (pathname !== '/coming-soon') {
+    return NextResponse.redirect(new URL('/coming-soon', request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: '/:path*',
+};

--- a/src/app/coming-soon/page.tsx
+++ b/src/app/coming-soon/page.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function ComingSoon() {
+  return (
+    <div className="min-h-screen w-full bg-[url('/backgrounds/hero-background.svg')] bg-cover bg-center flex items-center justify-center">
+      <h1 className="text-white text-5xl font-bold drop-shadow">Coming Soon</h1>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,28 +1,9 @@
-import type { Metadata, Viewport } from "next";
 import React from "react";
 import "./globals.css";
 
-export const metadata: Metadata = {
-  title: "Lions of Zion - Global Narrative Pulse",
-  description: "Defend Truth. Expose Lies. Monitor the global pulse of information.",
-  keywords: ["truth", "information", "narrative", "lions", "zion", "pulse"],
-  authors: [{ name: "Lions of Zion" }],
-  icons: {
-    icon: "/assets/images/logo.png.svg",
-    apple: "/assets/images/logo.png.svg",
-  },
-};
-
-export const viewport: Viewport = {
-  width: "device-width",
-  initialScale: 1,
-};
-
 export default function RootLayout({
   children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+}: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en">
       <body className="antialiased">{children}</body>


### PR DESCRIPTION
## Summary
- show a placeholder Coming Soon page
- redirect all routes there via middleware
- simplify layout to only inject global styles

## Testing
- `npm ci`
- `npm run build`
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68646c789964833092ebd102bc9c2e73