### PR TITLE
Add Jest setup and Hero component test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,13 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({ dir: './' });
+
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  testEnvironment: 'jest-environment-jsdom',
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect';

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "check:deps": "npm ls --depth=0",
-    "check:build-deps": "node -e \"try{require('tailwindcss'); console.log('✓ Tailwind CSS available')}catch{console.log('✗ Tailwind CSS missing')}\" && node -e \"try{require('postcss'); console.log('✓ PostCSS available')}catch{console.log('✗ PostCSS missing')}\""
+    "check:build-deps": "node -e \"try{require('tailwindcss'); console.log('✓ Tailwind CSS available')}catch{console.log('✗ Tailwind CSS missing')}\" && node -e \"try{require('postcss'); console.log('✓ PostCSS available')}catch{console.log('✗ PostCSS missing')}\"",
+    "test": "jest"
   },
   "dependencies": {
     "autoprefixer": "^10.4.21",
@@ -21,12 +22,17 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4.1.11",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest": "^30.0.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "depcheck": "^1.4.7",
     "eslint": "^9",
     "eslint-config-next": "15.3.4",
+    "jest": "^30.0.3",
+    "jest-environment-jsdom": "^30.0.2",
     "jscpd": "^4.0.5",
     "typescript": "^5"
   }

--- a/src/components/ui/__tests__/Hero.test.tsx
+++ b/src/components/ui/__tests__/Hero.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import Hero from '../Hero';
+
+describe('Hero component', () => {
+  it('renders the heading "LIONS OF ZION"', () => {
+    render(<Hero />);
+    const heading = screen.getByRole('heading', { name: /lions of zion/i });
+    expect(heading).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Jest configuration with React Testing Library setup
- create a simple test for the Hero component
- expose a `test` npm script

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/jest-dom/extend-expect')*

------
https://chatgpt.com/codex/tasks/task_e_68646e91945c8330965080a412a61d90