### PR TITLE
Fix heartbeat canvas scaling

### DIFF
--- a/src/components/HeartbeatLine.tsx
+++ b/src/components/HeartbeatLine.tsx
@@ -74,7 +74,8 @@ export default function HeartbeatLine() {
       canvas.width = rect.width * dpr;
       canvas.height = rect.height * dpr;
 
-      // Scale the drawing context so everything will work at the higher ratio
+      // Reset any existing transforms then scale for the current DPR
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
       ctx.scale(dpr, dpr);
 
       // Set display size (CSS pixels)


### PR DESCRIPTION
## Summary
- reset canvas transforms before applying DPR scaling

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68646b42ae6c83309c698b4620c2c346