### PR TITLE
Fix GitHub Actions checkout extraheader

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Check .git permissions
         run: ls -la .git


### PR DESCRIPTION
## Summary
- update checkout to v4 and disable persist credentials in azure workflow

## Testing
- `npm ci`
- `npm run build` *(fails: `tailwindcss` used directly as PostCSS plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68646f6323048330931348428dd59205